### PR TITLE
Fix header of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#java\_text\_tables
+# java\_text\_tables
 
 **Text Table Library in Java**
 


### PR DESCRIPTION
The header on the readme was improperly formatted so the markdown didn't render correctly.